### PR TITLE
feat: implement subscription-scoped pricing via Consumption API

### DIFF
--- a/src/az_scout_avs_sku/avs_data.py
+++ b/src/az_scout_avs_sku/avs_data.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import requests
+from az_scout.azure_api._auth import AZURE_MGMT_URL, _get_headers
 
 from az_scout_avs_sku._log import logger
 
@@ -19,6 +20,7 @@ AZURE_PRICES_BASE_URL = "https://prices.azure.com/api/retail/prices"
 REQUEST_TIMEOUT_SECONDS = 20
 CACHE_TTL = timedelta(minutes=30)
 PAYG_MONTH_HOURS = 730
+CONSUMPTION_API_VERSION = "2023-05-01"
 PRICE_MODES = (
     "payg_hour",
     "payg_month",
@@ -41,7 +43,7 @@ GENERATION2_AV64_REGIONS = {
 }
 
 _sku_cache: tuple[datetime, list[dict[str, Any]]] | None = None
-_prices_cache: dict[tuple[str, bool], tuple[datetime, dict[str, dict[str, Any]]]] = {}
+_prices_cache: dict[tuple[str, bool, str, str], tuple[datetime, dict[str, dict[str, Any]]]] = {}
 
 
 def _http_get_json(url: str) -> dict[str, Any] | list[Any]:
@@ -141,13 +143,117 @@ def _fetch_regional_price_items(region: str) -> list[dict[str, Any]]:
     return items
 
 
-def _build_price_index(region: str, byol: bool) -> dict[str, dict[str, Any]]:
-    cache_key = (region, byol)
+def _fetch_subscription_price_sheet(
+    subscription_id: str,
+) -> dict[str, float]:
+    """Fetch AVS meter prices from the Consumption Price Sheet API.
+
+    Uses az-scout's ``_get_headers`` to obtain a Bearer token for the
+    connected identity.  Returns a mapping of ``meterId`` (lowercase) to
+    ``unitPrice`` for AVS-related meters only.
+    """
+    headers = _get_headers()
+    url: str | None = (
+        f"{AZURE_MGMT_URL}/subscriptions/{subscription_id}"
+        f"/providers/Microsoft.Consumption/pricesheets/default"
+        f"?api-version={CONSUMPTION_API_VERSION}"
+    )
+    meter_prices: dict[str, float] = {}
+
+    while url:
+        resp = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+        if resp.status_code == 404:
+            msg = (
+                f"Subscription price sheet not available for subscription "
+                f"'{subscription_id}'. This API requires an Enterprise Agreement (EA) "
+                f"or Microsoft Customer Agreement (MCA) billing account."
+            )
+            raise ValueError(msg)
+        resp.raise_for_status()
+        data = resp.json()
+        properties = data.get("properties", {})
+        pricesheets = properties.get("pricesheets", [])
+
+        for item in pricesheets:
+            if not isinstance(item, dict):
+                continue
+            category = str(item.get("meterCategory", "")).lower()
+            subcategory = str(item.get("meterSubCategory", "")).lower()
+            if "specialized compute" not in category:
+                continue
+            if "azure vmware solution" not in subcategory:
+                continue
+
+            meter_id = str(item.get("meterId", "")).lower()
+            unit_price = item.get("unitPrice")
+            if meter_id and isinstance(unit_price, (int, float)):
+                meter_prices[meter_id] = float(unit_price)
+
+        url = properties.get("nextLink")
+
+    logger.info(
+        "Fetched %d AVS meter prices from subscription price sheet for sub=%s",
+        len(meter_prices),
+        subscription_id,
+    )
+    return meter_prices
+
+
+def _apply_subscription_prices(
+    items: list[dict[str, Any]],
+    subscription_id: str,
+) -> list[dict[str, Any]]:
+    """Override retail prices with subscription-specific prices.
+
+    Fetches the subscription's Consumption Price Sheet using az-scout's
+    authentication helpers and replaces ``retailPrice`` for matching
+    meter IDs.  Raises on any failure so callers get an explicit error
+    instead of silently falling back to public prices.
+    """
+    meter_prices = _fetch_subscription_price_sheet(subscription_id)
+
+    if not meter_prices:
+        msg = (
+            f"No AVS meters found in the subscription price sheet "
+            f"for subscription '{subscription_id}'. "
+            f"Ensure the subscription has Azure VMware Solution pricing."
+        )
+        raise ValueError(msg)
+
+    applied = 0
+    result: list[dict[str, Any]] = []
+    for item in items:
+        meter_id = str(item.get("meterId", "")).lower()
+        if meter_id in meter_prices:
+            item = {**item, "retailPrice": meter_prices[meter_id]}
+            applied += 1
+        result.append(item)
+
+    logger.info(
+        "Applied %d subscription prices (of %d total items) for sub=%s",
+        applied,
+        len(items),
+        subscription_id,
+    )
+    return result
+
+
+def _build_price_index(
+    region: str,
+    byol: bool,
+    pricing_source: str = "public",
+    subscription_id: str = "",
+) -> dict[str, dict[str, Any]]:
+    cache_key = (region, byol, pricing_source, subscription_id)
     cached = _prices_cache.get(cache_key)
     if cached and _is_cache_fresh(cached[0]):
         return cached[1]
 
     items = _fetch_regional_price_items(region)
+
+    if pricing_source == "subscription" and subscription_id:
+        items = _apply_subscription_prices(items, subscription_id)
+
     prices_by_sku: dict[str, dict[str, Any]] = {}
 
     def get_or_create_price_entry(sku_code: str) -> dict[str, Any]:
@@ -249,7 +355,12 @@ def get_avs_skus_for_region(
     normalized_subscription_id = (subscription_id or "").strip()
     technical_skus = get_avs_sku_technical_data()
     if normalized_region:
-        price_index = _build_price_index(region=normalized_region, byol=byol)
+        price_index = _build_price_index(
+            region=normalized_region,
+            byol=byol,
+            pricing_source=normalized_pricing_source,
+            subscription_id=normalized_subscription_id,
+        )
     else:
         price_index = {}
 

--- a/src/az_scout_avs_sku/routes.py
+++ b/src/az_scout_avs_sku/routes.py
@@ -1,20 +1,21 @@
 """API routes for AVS SKU and pricing data."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
 from az_scout_avs_sku.avs_data import get_avs_skus_for_region
 
 router = APIRouter()
 
 
-@router.get("/skus")
+@router.get("/skus", response_model=None)
 async def skus(
     region: str = "",
     byol: bool = True,
     sku: str = "",
     pricing_source: str = "public",
     subscription_id: str = "",
-) -> dict[str, object]:
+) -> dict[str, object] | JSONResponse:
     """Return AVS SKUs with technical data and optional regional pricing."""
     normalized_region = region.strip().lower()
     normalized_sku = sku.strip()
@@ -29,8 +30,15 @@ async def skus(
             pricing_source=normalized_pricing_source,
             subscription_id=normalized_subscription_id,
         )
+    except ValueError as exc:
+        message = f"Failed to load AVS SKU data for region '{normalized_region}': {exc}"
+        return JSONResponse(
+            status_code=422,
+            content={"error": message, "detail": message},
+        )
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(
+        message = f"Failed to load AVS SKU data for region '{normalized_region}': {exc}"
+        return JSONResponse(
             status_code=502,
-            detail=f"Failed to load AVS SKU data for region '{normalized_region}': {exc}",
-        ) from exc
+            content={"error": message, "detail": message},
+        )

--- a/src/az_scout_avs_sku/static/js/avs-sku-tab.js
+++ b/src/az_scout_avs_sku/static/js/avs-sku-tab.js
@@ -301,8 +301,12 @@
             byolToggle.disabled = true;
             pricingScopeSelect.disabled = true;
             hideLegend();
-            statusEl.textContent =
-                `Loading AVS SKUs for ${ctx.regionName} (${pricingSource}, ${byol ? "BYOL" : "No BYOL"}, ${selectedModeLabel})…`;
+            statusEl.textContent = "";
+            cardsEl.innerHTML =
+                `<div class="alert alert-info fade show" role="alert" style="grid-column: 1 / -1;">` +
+                `<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>` +
+                `Loading AVS SKUs for ${ctx.regionName} (${pricingSource}, ${byol ? "BYOL" : "No BYOL"}, ${selectedModeLabel})…` +
+                `</div>`;
 
             try {
                 const qs = new URLSearchParams({
@@ -318,12 +322,16 @@
                 rerenderCurrentItems();
                 const activeCount = countActiveSkus(currentItems, priceModeSelect.value);
                 statusEl.textContent =
-                    `${activeCount} SKU are available in ${ctx.regionName} (${pricingSource}, ${selectedModeLabel}).`;
+                    `${activeCount} SKU ${activeCount === 1 ? "is" : "are"} available in ${ctx.regionName} (${pricingSource}, ${selectedModeLabel}).`;
                 showLegend();
             } catch (e) {
                 currentItems = [];
-                cardsEl.innerHTML = "";
-                statusEl.textContent = "Error: " + e.message;
+                cardsEl.innerHTML =
+                    `<div class="alert alert-danger alert-dismissible fade show" role="alert" style="grid-column: 1 / -1;">` +
+                    `<strong>Error:</strong> ${e.message}` +
+                    `<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>` +
+                    `</div>`;
+                statusEl.textContent = "";
                 hideLegend();
             } finally {
                 byolToggle.disabled = false;
@@ -347,7 +355,7 @@
             rerenderCurrentItems();
             const activeCount = countActiveSkus(currentItems, priceModeSelect.value);
             statusEl.textContent =
-                `Showing ${activeCount} SKU card(s) for ${ctx.regionName} (${pricingSource}, ${selectedModeLabel}).`;
+                `Showing ${activeCount} SKU ${activeCount === 1 ? "card" : "cards"} for ${ctx.regionName} (${pricingSource}, ${selectedModeLabel}).`;
         });
 
         hideLegend();

--- a/tests/test_avs_data.py
+++ b/tests/test_avs_data.py
@@ -1,0 +1,258 @@
+"""Tests for AVS data helpers – subscription-scoped pricing path."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from az_scout_avs_sku.avs_data import (
+    _apply_subscription_prices,
+    _build_price_index,
+    _fetch_subscription_price_sheet,
+    _prices_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_retail_item(
+    meter_id: str = "meter-1",
+    meter_name: str = "AV36 Node",
+    sku_name: str = "AV36 Node",
+    retail_price: float = 10.0,
+    item_type: str = "Consumption",
+    reservation_term: str = "",
+    effective_start: str = "2025-01-01",
+    currency: str = "USD",
+) -> dict[str, Any]:
+    """Build a Retail Prices API item dict."""
+    item: dict[str, Any] = {
+        "meterId": meter_id,
+        "meterName": meter_name,
+        "skuName": sku_name,
+        "retailPrice": retail_price,
+        "type": item_type,
+        "effectiveStartDate": effective_start,
+        "currencyCode": currency,
+    }
+    if reservation_term:
+        item["reservationTerm"] = reservation_term
+    return item
+
+
+def _make_pricesheet_item(
+    meter_id: str = "meter-1",
+    meter_name: str = "AV36 Node",
+    unit_price: float = 8.0,
+    meter_category: str = "Specialized Compute",
+    meter_subcategory: str = "Azure VMware Solution",
+) -> dict[str, Any]:
+    """Build a Consumption Price Sheet item dict."""
+    return {
+        "meterId": meter_id,
+        "meterName": meter_name,
+        "unitPrice": unit_price,
+        "currencyCode": "USD",
+        "meterCategory": meter_category,
+        "meterSubCategory": meter_subcategory,
+        "unitOfMeasure": "1 Hour",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _fetch_subscription_price_sheet
+# ---------------------------------------------------------------------------
+
+
+@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
+@patch("az_scout_avs_sku.avs_data.requests.get")
+def test_fetch_subscription_price_sheet_returns_avs_meters(
+    mock_get: MagicMock,
+    _mock_headers: MagicMock,
+) -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "properties": {
+            "pricesheets": [
+                _make_pricesheet_item(meter_id="aaa", unit_price=8.5),
+                _make_pricesheet_item(
+                    meter_id="bbb",
+                    meter_category="Virtual Machines",
+                    meter_subcategory="Dv5 Series",
+                    unit_price=0.5,
+                ),
+            ],
+            "nextLink": None,
+        },
+    }
+    mock_get.return_value = mock_resp
+
+    result = _fetch_subscription_price_sheet("sub-123")
+
+    assert result == {"aaa": 8.5}
+    _mock_headers.assert_called_once()
+
+
+@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
+@patch("az_scout_avs_sku.avs_data.requests.get")
+def test_fetch_subscription_price_sheet_follows_pagination(
+    mock_get: MagicMock,
+    _mock_headers: MagicMock,
+) -> None:
+    page1 = MagicMock()
+    page1.status_code = 200
+    page1.raise_for_status = MagicMock()
+    page1.json.return_value = {
+        "properties": {
+            "pricesheets": [_make_pricesheet_item(meter_id="m1", unit_price=5.0)],
+            "nextLink": "https://next-page",
+        },
+    }
+
+    page2 = MagicMock()
+    page2.status_code = 200
+    page2.raise_for_status = MagicMock()
+    page2.json.return_value = {
+        "properties": {
+            "pricesheets": [_make_pricesheet_item(meter_id="m2", unit_price=6.0)],
+            "nextLink": None,
+        },
+    }
+
+    mock_get.side_effect = [page1, page2]
+
+    result = _fetch_subscription_price_sheet("sub-456")
+
+    assert result == {"m1": 5.0, "m2": 6.0}
+    assert mock_get.call_count == 2
+
+
+@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
+@patch("az_scout_avs_sku.avs_data.requests.get")
+def test_fetch_subscription_price_sheet_raises_on_404(
+    mock_get: MagicMock,
+    _mock_headers: MagicMock,
+) -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_get.return_value = mock_resp
+
+    with pytest.raises(ValueError, match="Enterprise Agreement"):
+        _fetch_subscription_price_sheet("sub-no-ea")
+
+
+# ---------------------------------------------------------------------------
+# _apply_subscription_prices
+# ---------------------------------------------------------------------------
+
+
+@patch("az_scout_avs_sku.avs_data._fetch_subscription_price_sheet")
+def test_apply_subscription_prices_overrides_retail(
+    mock_fetch: MagicMock,
+) -> None:
+    mock_fetch.return_value = {"meter-a": 7.5}
+
+    items = [
+        _make_retail_item(meter_id="meter-a", retail_price=10.0),
+        _make_retail_item(meter_id="meter-b", retail_price=12.0),
+    ]
+    result = _apply_subscription_prices(items, "sub-1")
+
+    assert len(result) == 2
+    assert result[0]["retailPrice"] == 7.5
+    assert result[1]["retailPrice"] == 12.0  # unchanged
+
+
+@patch("az_scout_avs_sku.avs_data._fetch_subscription_price_sheet")
+def test_apply_subscription_prices_raises_on_failure(
+    mock_fetch: MagicMock,
+) -> None:
+    mock_fetch.side_effect = RuntimeError("auth failed")
+
+    items = [_make_retail_item(retail_price=10.0)]
+    with pytest.raises(RuntimeError, match="auth failed"):
+        _apply_subscription_prices(items, "sub-1")
+
+
+@patch("az_scout_avs_sku.avs_data._fetch_subscription_price_sheet")
+def test_apply_subscription_prices_raises_when_no_meters(
+    mock_fetch: MagicMock,
+) -> None:
+    mock_fetch.return_value = {}
+
+    items = [_make_retail_item(retail_price=10.0)]
+    with pytest.raises(ValueError, match="No AVS meters found"):
+        _apply_subscription_prices(items, "sub-1")
+
+
+@patch("az_scout_avs_sku.avs_data._fetch_subscription_price_sheet")
+def test_apply_subscription_prices_case_insensitive_meter_id(
+    mock_fetch: MagicMock,
+) -> None:
+    mock_fetch.return_value = {"meter-abc": 5.0}
+
+    items = [_make_retail_item(meter_id="METER-ABC", retail_price=10.0)]
+    result = _apply_subscription_prices(items, "sub-1")
+
+    assert result[0]["retailPrice"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# _build_price_index – subscription routing
+# ---------------------------------------------------------------------------
+
+
+@patch("az_scout_avs_sku.avs_data._apply_subscription_prices")
+@patch("az_scout_avs_sku.avs_data._fetch_regional_price_items")
+def test_build_price_index_calls_subscription_path(
+    mock_fetch_public: MagicMock,
+    mock_apply_sub: MagicMock,
+) -> None:
+    _prices_cache.clear()
+
+    public_items = [
+        _make_retail_item(meter_id="m1", sku_name="AV36 Node", retail_price=10.0),
+    ]
+    mock_fetch_public.return_value = public_items
+    mock_apply_sub.return_value = [
+        _make_retail_item(meter_id="m1", sku_name="AV36 Node", retail_price=7.0),
+    ]
+
+    result = _build_price_index(
+        region="eastus",
+        byol=False,
+        pricing_source="subscription",
+        subscription_id="sub-1",
+    )
+
+    mock_apply_sub.assert_called_once_with(public_items, "sub-1")
+    assert result["AV36"]["payg_hour"] == 7.0
+
+
+@patch("az_scout_avs_sku.avs_data._apply_subscription_prices")
+@patch("az_scout_avs_sku.avs_data._fetch_regional_price_items")
+def test_build_price_index_skips_subscription_for_public(
+    mock_fetch_public: MagicMock,
+    mock_apply_sub: MagicMock,
+) -> None:
+    _prices_cache.clear()
+
+    mock_fetch_public.return_value = [
+        _make_retail_item(meter_id="m1", sku_name="AV36 Node", retail_price=10.0),
+    ]
+
+    result = _build_price_index(
+        region="eastus",
+        byol=False,
+        pricing_source="public",
+        subscription_id="",
+    )
+
+    mock_apply_sub.assert_not_called()
+    assert result["AV36"]["payg_hour"] == 10.0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -57,5 +57,20 @@ def test_skus_route_wraps_upstream_errors() -> None:
 
     assert response.status_code == 502
     body = response.json()
-    assert "Failed to load AVS SKU data" in body["detail"]
-    assert "eastus" in body["detail"]
+    assert "Failed to load AVS SKU data" in body["error"]
+    assert "eastus" in body["error"]
+    assert body["detail"] == body["error"]
+
+
+def test_skus_route_returns_422_for_value_errors() -> None:
+    with patch(
+        "az_scout_avs_sku.routes.get_avs_skus_for_region",
+        side_effect=ValueError("No AVS meters found"),
+    ):
+        client = _build_client()
+        response = client.get("/plugins/avs-sku/skus", params={"region": "eastus"})
+
+    assert response.status_code == 422
+    body = response.json()
+    assert "No AVS meters found" in body["error"]
+    assert body["detail"] == body["error"]


### PR DESCRIPTION
## Summary

Implements subscription-scoped pricing for issue #5 by leveraging az-scout's authentication facilitators to call the Azure Consumption Price Sheet API.

## Changes

### Backend (`avs_data.py`)
- **`_fetch_subscription_price_sheet()`** — Fetches AVS meter prices from the Consumption Price Sheet API using az-scout's `_get_headers()` for Bearer token authentication. Supports pagination and filters for AVS meters only.
- **`_apply_subscription_prices()`** — Overrides `retailPrice` in public retail items by matching `meterId` with subscription-specific unit prices.
- **`_build_price_index()`** — Now accepts `pricing_source` and `subscription_id`; dispatches to subscription path when `pricing_source=subscription`.
- Raises explicit `ValueError` on 404 (non-EA/MCA subscriptions) and empty price sheets instead of silent fallback.

### Routes (`routes.py`)
- Split error handling: **422** for `ValueError` (invalid pricing parameters), **502** for upstream failures.
- Return `{"error": ..., "detail": ...}` JSON for compatibility with az-scout's `apiFetch` error parsing.

### Frontend (`avs-sku-tab.js`)
- Show Bootstrap `alert-info` with spinner during loading state.
- Show dismissible `alert-danger` spanning full grid width on errors, displaying the descriptive error message.
- Fix singular/plural grammar: "1 SKU is available" vs "N SKU are available".

### Tests
- New `test_avs_data.py` with 9 tests covering `_fetch_subscription_price_sheet`, `_apply_subscription_prices`, and `_build_price_index` subscription routing.
- Updated `test_routes.py` with a test for the 422 `ValueError` path.

## Notes

- Subscription pricing requires an Enterprise Agreement (EA) or Microsoft Customer Agreement (MCA) billing account. A clear error message is shown for unsupported subscription types.
- Public pricing remains the default and works for all users.

Closes #5