### PR TITLE
fix: module docstring, migrate to PluginError and arm_get

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Azure VMware Solution (AVS) SKU exploration plugin for az-scout"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "az-scout>=2026.3.2",
+    "az-scout>=2026.3.4",
     "fastapi",
     "requests>=2.28",
 ]

--- a/src/az_scout_avs_sku/__init__.py
+++ b/src/az_scout_avs_sku/__init__.py
@@ -1,7 +1,7 @@
-"""az-scout example plugin.
+"""az-scout AVS SKU plugin.
 
-This is a minimal plugin scaffold. Customise the class below
-to add your own routes, MCP tools, UI tabs, and chat modes.
+Adds Azure VMware Solution (AVS) SKU exploration with regional
+pricing, generation compatibility, and technical specifications.
 """
 
 from collections.abc import Callable

--- a/src/az_scout_avs_sku/avs_data.py
+++ b/src/az_scout_avs_sku/avs_data.py
@@ -8,7 +8,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import requests
-from az_scout.azure_api._auth import AZURE_MGMT_URL, _get_headers
+from az_scout.azure_api import AZURE_MGMT_URL, ArmNotFoundError, arm_get
 
 from az_scout_avs_sku._log import logger
 
@@ -148,11 +148,10 @@ def _fetch_subscription_price_sheet(
 ) -> dict[str, float]:
     """Fetch AVS meter prices from the Consumption Price Sheet API.
 
-    Uses az-scout's ``_get_headers`` to obtain a Bearer token for the
-    connected identity.  Returns a mapping of ``meterId`` (lowercase) to
-    ``unitPrice`` for AVS-related meters only.
+    Uses az-scout's ``arm_get`` to make authenticated ARM calls with
+    built-in retry and error handling.  Returns a mapping of
+    ``meterId`` (lowercase) to ``unitPrice`` for AVS-related meters only.
     """
-    headers = _get_headers()
     url: str | None = (
         f"{AZURE_MGMT_URL}/subscriptions/{subscription_id}"
         f"/providers/Microsoft.Consumption/pricesheets/default"
@@ -161,16 +160,15 @@ def _fetch_subscription_price_sheet(
     meter_prices: dict[str, float] = {}
 
     while url:
-        resp = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-        if resp.status_code == 404:
+        try:
+            data = arm_get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        except ArmNotFoundError:
             msg = (
                 f"Subscription price sheet not available for subscription "
                 f"'{subscription_id}'. This API requires an Enterprise Agreement (EA) "
                 f"or Microsoft Customer Agreement (MCA) billing account."
             )
-            raise ValueError(msg)
-        resp.raise_for_status()
-        data = resp.json()
+            raise ValueError(msg)  # noqa: B904
         properties = data.get("properties", {})
         pricesheets = properties.get("pricesheets", [])
 

--- a/src/az_scout_avs_sku/routes.py
+++ b/src/az_scout_avs_sku/routes.py
@@ -1,21 +1,21 @@
 """API routes for AVS SKU and pricing data."""
 
+from az_scout.plugin_api import PluginUpstreamError, PluginValidationError
 from fastapi import APIRouter
-from fastapi.responses import JSONResponse
 
 from az_scout_avs_sku.avs_data import get_avs_skus_for_region
 
 router = APIRouter()
 
 
-@router.get("/skus", response_model=None)
+@router.get("/skus")
 async def skus(
     region: str = "",
     byol: bool = True,
     sku: str = "",
     pricing_source: str = "public",
     subscription_id: str = "",
-) -> dict[str, object] | JSONResponse:
+) -> dict[str, object]:
     """Return AVS SKUs with technical data and optional regional pricing."""
     normalized_region = region.strip().lower()
     normalized_sku = sku.strip()
@@ -31,14 +31,8 @@ async def skus(
             subscription_id=normalized_subscription_id,
         )
     except ValueError as exc:
-        message = f"Failed to load AVS SKU data for region '{normalized_region}': {exc}"
-        return JSONResponse(
-            status_code=422,
-            content={"error": message, "detail": message},
-        )
+        raise PluginValidationError(str(exc)) from exc
     except Exception as exc:  # noqa: BLE001
-        message = f"Failed to load AVS SKU data for region '{normalized_region}': {exc}"
-        return JSONResponse(
-            status_code=502,
-            content={"error": message, "detail": message},
-        )
+        raise PluginUpstreamError(
+            f"Failed to load AVS SKU data for region '{normalized_region}': {exc}"
+        ) from exc

--- a/tests/test_avs_data.py
+++ b/tests/test_avs_data.py
@@ -68,16 +68,11 @@ def _make_pricesheet_item(
 # ---------------------------------------------------------------------------
 
 
-@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
-@patch("az_scout_avs_sku.avs_data.requests.get")
+@patch("az_scout_avs_sku.avs_data.arm_get")
 def test_fetch_subscription_price_sheet_returns_avs_meters(
-    mock_get: MagicMock,
-    _mock_headers: MagicMock,
+    mock_arm_get: MagicMock,
 ) -> None:
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.raise_for_status = MagicMock()
-    mock_resp.json.return_value = {
+    mock_arm_get.return_value = {
         "properties": {
             "pricesheets": [
                 _make_pricesheet_item(meter_id="aaa", unit_price=8.5),
@@ -91,57 +86,44 @@ def test_fetch_subscription_price_sheet_returns_avs_meters(
             "nextLink": None,
         },
     }
-    mock_get.return_value = mock_resp
 
     result = _fetch_subscription_price_sheet("sub-123")
 
     assert result == {"aaa": 8.5}
-    _mock_headers.assert_called_once()
+    mock_arm_get.assert_called_once()
 
 
-@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
-@patch("az_scout_avs_sku.avs_data.requests.get")
+@patch("az_scout_avs_sku.avs_data.arm_get")
 def test_fetch_subscription_price_sheet_follows_pagination(
-    mock_get: MagicMock,
-    _mock_headers: MagicMock,
+    mock_arm_get: MagicMock,
 ) -> None:
-    page1 = MagicMock()
-    page1.status_code = 200
-    page1.raise_for_status = MagicMock()
-    page1.json.return_value = {
+    page1 = {
         "properties": {
             "pricesheets": [_make_pricesheet_item(meter_id="m1", unit_price=5.0)],
             "nextLink": "https://next-page",
         },
     }
-
-    page2 = MagicMock()
-    page2.status_code = 200
-    page2.raise_for_status = MagicMock()
-    page2.json.return_value = {
+    page2 = {
         "properties": {
             "pricesheets": [_make_pricesheet_item(meter_id="m2", unit_price=6.0)],
             "nextLink": None,
         },
     }
-
-    mock_get.side_effect = [page1, page2]
+    mock_arm_get.side_effect = [page1, page2]
 
     result = _fetch_subscription_price_sheet("sub-456")
 
     assert result == {"m1": 5.0, "m2": 6.0}
-    assert mock_get.call_count == 2
+    assert mock_arm_get.call_count == 2
 
 
-@patch("az_scout_avs_sku.avs_data._get_headers", return_value={"Authorization": "Bearer tok"})
-@patch("az_scout_avs_sku.avs_data.requests.get")
+@patch("az_scout_avs_sku.avs_data.arm_get")
 def test_fetch_subscription_price_sheet_raises_on_404(
-    mock_get: MagicMock,
-    _mock_headers: MagicMock,
+    mock_arm_get: MagicMock,
 ) -> None:
-    mock_resp = MagicMock()
-    mock_resp.status_code = 404
-    mock_get.return_value = mock_resp
+    from az_scout.azure_api import ArmNotFoundError
+
+    mock_arm_get.side_effect = ArmNotFoundError("Not found")
 
     with pytest.raises(ValueError, match="Enterprise Agreement"):
         _fetch_subscription_price_sheet("sub-no-ea")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
+from az_scout.plugin_api import PluginError
 from fastapi import FastAPI
+from fastapi.requests import Request
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from az_scout_avs_sku.routes import router
@@ -8,6 +11,14 @@ from az_scout_avs_sku.routes import router
 
 def _build_client() -> TestClient:
     app = FastAPI()
+
+    @app.exception_handler(PluginError)
+    async def _plugin_error_handler(_request: Request, exc: PluginError) -> JSONResponse:
+        return JSONResponse(
+            {"error": str(exc), "detail": str(exc)},
+            status_code=exc.status_code,
+        )
+
     app.include_router(router, prefix="/plugins/avs-sku")
     return TestClient(app)
 

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "az-scout"
-version = "2026.3.2"
+version = "2026.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity" },
@@ -54,11 +54,12 @@ dependencies = [
     { name = "jinja2" },
     { name = "mcp", extra = ["cli"] },
     { name = "requests" },
+    { name = "rich" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/40/8dc6a81c63dfd79e1e06dab39373383e35db4688f0cef787f4ea202c8a82/az_scout-2026.3.2.tar.gz", hash = "sha256:a5e84f3f563562f6958d1283c746284ed37b93ede81d352caf879a09edc2d421", size = 1288614, upload-time = "2026-03-05T10:56:59.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/fb/0d44379828dee49bfba10e9206c17a5dee09198b3f66609346d1be864eb8/az_scout-2026.3.4.tar.gz", hash = "sha256:a2631d1ea1e00b995fe153ac9a85f81f9e2688c8846f27423499d63e7321cc8c", size = 1296894, upload-time = "2026-03-08T11:23:00.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/f6/f297c2a847d76a4e5fe301388d94a86f532bbb5fa78babd7e5e5b803b0e0/az_scout-2026.3.2-py3-none-any.whl", hash = "sha256:2ecdeffef3943b46d163f982519d81c21417d993d4f47063ad2c89663f4e71e2", size = 155146, upload-time = "2026-03-05T10:56:57.659Z" },
+    { url = "https://files.pythonhosted.org/packages/49/80/e1b91487a5d265e523a71107c79904712701ad5d49226be3d09f6d3f3e88/az_scout-2026.3.4-py3-none-any.whl", hash = "sha256:1e061c88895f4918e101b284e8c902f1d17debbe3ddf88ebf9a9218b08a6cc54", size = 155453, upload-time = "2026-03-08T11:22:58.314Z" },
 ]
 
 [[package]]
@@ -82,7 +83,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "az-scout", specifier = ">=2026.3.2" },
+    { name = "az-scout", specifier = ">=2026.3.4" },
     { name = "fastapi" },
     { name = "requests", specifier = ">=2.28" },
 ]


### PR DESCRIPTION
## Summary

Three housekeeping fixes leveraging the new az-scout 2026.3.4 plugin APIs.

## Changes

### #8 — Module docstring
Replaced the leftover scaffold docstring in `__init__.py` with a proper description.

### #9 — Migrate to `PluginError` exceptions
- Replaced manual `try/except → JSONResponse` in `routes.py` with `PluginValidationError` (422) and `PluginUpstreamError` (502) from `az_scout.plugin_api`
- Removed `JSONResponse` import, `response_model=None` override, and the union return type
- The core app's global exception handler now produces the `{"error": …, "detail": …}` response automatically

### #10 — Migrate to `arm_get`
- Replaced `from az_scout.azure_api._auth import _get_headers` (internal API) with `from az_scout.azure_api import arm_get, ArmNotFoundError` (public API)
- `_fetch_subscription_price_sheet()` now uses `arm_get()` which provides automatic Bearer auth, 429/5xx retry with backoff, and structured error types
- Manual 404 status check replaced by `ArmNotFoundError` catch

### Dependencies
- Bumped `az-scout>=2026.3.4` (`PLUGIN_API_VERSION=1.1`)

### Tests
- Updated `test_avs_data.py` to mock `arm_get` directly instead of `_get_headers` + `requests.get`
- Updated `test_routes.py` to register `PluginError` exception handler on the test app

Closes #8, closes #9, closes #10